### PR TITLE
#5: Correzione del bug della fascia a sud della mappa

### DIFF
--- a/src/app/index.js
+++ b/src/app/index.js
@@ -88,6 +88,8 @@ window.API_DOMAIN = process.env.NODE_ENV !== 'production' ? 'http://localhost:80
             layer && map.removeLayer(layer);
             map.setView(initialCentroid, initialZoom);
         }
+
+        map.invalidateSize();
     };
 })();
 


### PR DESCRIPTION
Questa fix risolve la mancata visualizzazione di una fascia in basso. Lo fa invalidando le dimensioni della mappa dopo ogni caricamento dei dati.

È una fix veloce. Infatti l'invalidazione dovrebbe essere fatta una sola volta dopo la creazione della mappa, ma non è facile farla per come è strutturato il codice al momento.

Closes #5 